### PR TITLE
feat: add support for OpenAI o3 model

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Alternatively you can run the install script to add a desktop entry and set up t
 - Text-to-Speech output using OpenAI's TTS and TTS-HD models
 - Real-time voice conversation support using gpt-4o-realtime-preview model
 - Text to audio output using gpt-4o-audio-preview model
+- Reasoning support for OpenAI's o3 models
 
 ## Screenshots
 

--- a/src/ai_providers.py
+++ b/src/ai_providers.py
@@ -68,23 +68,24 @@ class OpenAIProvider(AIProvider):
                 return sorted([model.id for model in models])
             
             # Default filtering behavior
-            allowed_models = {"gpt-3.5-turbo", "gpt-4", "gpt-4-turbo-preview", "dall-e-3", 
-                            "gpt-4o-mini-realtime-preview", "o1-mini", "o1-preview", 
-                            "chatgpt-4o-latest", "gpt-4-turbo", "gpt-4-turbo-preview", 
-                            "gpt-4o-mini", "gpt-4o-audio-preview", "gpt-4o-mini-audio-preview", 
-                            "gpt-4o", "gpt-3.5-turbo-16k", "gpt-3.5-turbo-0125", "gpt-3.5-turbo", 
-                            "gpt-4o-realtime-preview", "gpt-4-0125-preview", "gpt-4", 
-                            "gpt-4-1106-preview"}
+            allowed_models = {"gpt-3.5-turbo", "gpt-4", "gpt-4-turbo-preview", "dall-e-3",
+                            "gpt-4o-mini-realtime-preview", "o1-mini", "o1-preview",
+                            "chatgpt-4o-latest", "gpt-4-turbo", "gpt-4-turbo-preview",
+                            "gpt-4o-mini", "gpt-4o-audio-preview", "gpt-4o-mini-audio-preview",
+                            "gpt-4o", "gpt-3.5-turbo-16k", "gpt-3.5-turbo-0125", "gpt-3.5-turbo",
+                            "gpt-4o-realtime-preview", "gpt-4-0125-preview", "gpt-4",
+                            "gpt-4-1106-preview", "o3", "o3-mini"}
             filtered_models = [model.id for model in models if model.id in allowed_models]
             return sorted(filtered_models)
         except Exception as e:
             print(f"Error fetching models: {e}")
             return sorted(["gpt-3.5-turbo", "gpt-4", "gpt-4-turbo-preview", "dall-e-3"])
-    
+
     def generate_chat_completion(self, messages, model, temperature=0.7, max_tokens=None, chat_id=None):
         # Check if this is an audio-capable model
         is_audio_model = "audio" in model.lower()
-        is_reasoning_model = "o1-mini" in model.lower() or "o1-preview" in model.lower()
+        reasoning_models = ["o1-mini", "o1-preview", "o3", "o3-mini"]
+        is_reasoning_model = any(r in model.lower() for r in reasoning_models)
         
         params = {}
         


### PR DESCRIPTION
## Summary
- include `o3` and `o3-mini` in allowed OpenAI models
- treat `o3` models as reasoning models for proper message formatting
- document o3 support in README

## Testing
- `python -m py_compile src/ai_providers.py`


------
https://chatgpt.com/codex/tasks/task_e_689765cffbdc8330b88e0107920c50bc