### PR TITLE
Add hanging indent support for bullet lists

### DIFF
--- a/src/ChatGTK.py
+++ b/src/ChatGTK.py
@@ -1595,6 +1595,121 @@ class OpenAIGTKClient(Gtk.Window):
         self.conversation_box.pack_start(lbl, False, False, 0)
         self.conversation_box.show_all()
 
+    def _register_link_tag(self, buffer: Gtk.TextBuffer, tag: Gtk.TextTag, url: str):
+        """Store link tag metadata on the buffer for click handling."""
+        if not hasattr(buffer, "_link_tags"):
+            buffer._link_tags = []
+        buffer._link_tags.append((tag, url))
+
+    def _insert_markup_with_links(self, buffer: Gtk.TextBuffer, markup_text: str):
+        """
+        Insert markup into the buffer while preserving clickable links.
+
+        Gtk.TextBuffer does not automatically create clickable anchors for
+        <a href="..."> spans, so we parse the markup, insert the label text, and
+        apply a tagged underline that we can handle manually.
+        """
+        link_pattern = re.compile(r'<a href="([^"]+)">(.*?)</a>')
+        pos = 0
+
+        for match in link_pattern.finditer(markup_text):
+            # Insert any preceding markup before the link
+            before = markup_text[pos:match.start()]
+            if before:
+                buffer.insert_markup(buffer.get_end_iter(), before, -1)
+
+            url = match.group(1)
+            label_markup = match.group(2)
+
+            # Record offsets before and after inserting the link label
+            start_offset = buffer.get_char_count()
+            buffer.insert_markup(buffer.get_end_iter(), label_markup, -1)
+            end_offset = buffer.get_char_count()
+
+            start_iter = buffer.get_iter_at_offset(start_offset)
+            end_iter = buffer.get_iter_at_offset(end_offset)
+
+            link_tag = buffer.create_tag(
+                None,
+                underline=Pango.Underline.SINGLE,
+            )
+            buffer.apply_tag(link_tag, start_iter, end_iter)
+            self._register_link_tag(buffer, link_tag, url)
+
+            pos = match.end()
+
+        # Insert any trailing content after the final link
+        if pos < len(markup_text):
+            buffer.insert_markup(buffer.get_end_iter(), markup_text[pos:], -1)
+
+    def _apply_bullet_hanging_indent(self, buffer: Gtk.TextBuffer):
+        """Apply a hanging indent to bullet list lines in the buffer."""
+        text = buffer.get_text(buffer.get_start_iter(), buffer.get_end_iter(), True)
+        if "•" not in text:
+            return
+
+        indent_tag = buffer.get_tag_table().lookup("bullet_hang")
+        if indent_tag is None:
+            indent_tag = buffer.create_tag("bullet_hang", left_margin=24, indent=-14)
+
+        offset = 0
+        for line in text.splitlines(True):  # Keep newline length for offset math
+            if re.match(r"^\s*•\s+", line):
+                line_start = buffer.get_iter_at_offset(offset)
+                # Exclude trailing newline from the tagged region
+                line_end = buffer.get_iter_at_offset(offset + len(line.rstrip("\n")))
+                buffer.apply_tag(indent_tag, line_start, line_end)
+            offset += len(line)
+
+    def _create_text_view(self, markup_text: str, text_color: str):
+        """Create a styled, read-only TextView with markup and hanging lists."""
+        text_view = Gtk.TextView()
+        text_view.set_wrap_mode(Gtk.WrapMode.WORD)
+        text_view.set_editable(False)
+        text_view.set_cursor_visible(False)
+        text_view.set_hexpand(True)
+
+        css_provider = Gtk.CssProvider()
+        css = f"""
+            textview {{
+                font-family: {self.font_family};
+                font-size: {self.font_size}pt;
+            }}
+            textview text {{
+                color: {text_color};
+            }}
+        """
+        css_provider.load_from_data(css.encode())
+        text_view.get_style_context().add_provider(
+            css_provider,
+            Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
+        )
+
+        buffer = text_view.get_buffer()
+        if markup_text:
+            self._insert_markup_with_links(buffer, markup_text)
+            self._apply_bullet_hanging_indent(buffer)
+
+        # Handle link clicks manually since TextView does not natively activate them
+        def on_event(view, event):
+            if event.type == Gdk.EventType.BUTTON_RELEASE and event.button == 1:
+                x, y = view.window_to_buffer_coords(
+                    Gtk.TextWindowType.WIDGET, int(event.x), int(event.y)
+                )
+                iter_at_click = view.get_iter_at_location(x, y)
+                if iter_at_click is None:
+                    return False
+
+                for tag in iter_at_click.get_tags():
+                    for stored_tag, url in getattr(buffer, "_link_tags", []):
+                        if tag == stored_tag:
+                            Gtk.show_uri_on_window(self.get_window(), url, Gdk.CURRENT_TIME)
+                            return True
+            return False
+
+        text_view.connect("event-after", on_event)
+        return text_view
+
     def append_ai_message(self, message_text):
         # Container for the entire AI response (including play/stop button)
         response_container = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
@@ -1692,55 +1807,28 @@ class OpenAIGTKClient(Gtk.Window):
                     processed = process_tex_markup(seg, self.latex_color, self.current_chat_id, self.source_theme, self.latex_dpi)
                     
                     if "<img" in processed:
-                        text_view = Gtk.TextView()
-                        text_view.set_wrap_mode(Gtk.WrapMode.WORD)
-                        text_view.set_editable(False)
-                        text_view.set_cursor_visible(False)
-                        text_view.set_hexpand(True)  # Make it expand horizontally
-                        #text_view.set_vexpand(True)
-                        text_view.set_size_request(100, -1)  # Set minimum width to 10px, natural height
-                        css_provider = Gtk.CssProvider()
-                        css = f"""
-                            textview {{
-                                font-family: {self.font_family};
-                                font-size: {self.font_size}pt;
-                            }}
-                            textview text {{
-                                color: {self.ai_color};
-                            }}
-                        """
-                        css_provider.load_from_data(css.encode())
-                        text_view.get_style_context().add_provider(
-                            css_provider,
-                            Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
-                        )
+                        text_view = self._create_text_view("", self.ai_color)
                         buffer = text_view.get_buffer()
                         parts = re.split(r'(<img src="[^"]+"/>)', processed)
-                        iter = buffer.get_start_iter()
                         for part in parts:
                             if part.startswith('<img src="'):
                                 img_path = re.search(r'src="([^"]+)"', part).group(1)
+                                insert_iter = buffer.get_end_iter()
                                 # LaTeX math images stay at their natural (small) size
                                 if self._is_latex_math_image(img_path):
-                                    insert_tex_image(buffer, iter, img_path, text_view, self, is_math_image=True)
+                                    insert_tex_image(buffer, insert_iter, img_path, text_view, self, is_math_image=True)
                                 else:
                                     # Model-generated or other non-math images resize with chat width
-                                    insert_resized_image(buffer, iter, img_path, text_view, self)
+                                    insert_resized_image(buffer, insert_iter, img_path, text_view, self)
                             else:
                                 text = process_text_formatting(part, self.font_size)
-                                buffer.insert_markup(iter, text, -1)
+                                self._insert_markup_with_links(buffer, text)
+                        self._apply_bullet_hanging_indent(buffer)
                         content_container.pack_start(text_view, False, False, 0)
                     else:
                         processed = process_inline_markup(processed, self.font_size)
-                        lbl_ai_text = Gtk.Label()
-                        lbl_ai_text.set_selectable(True)
-                        lbl_ai_text.set_line_wrap(True)
-                        lbl_ai_text.set_line_wrap_mode(Gtk.WrapMode.WORD)
-                        lbl_ai_text.set_xalign(0)
-                        self.apply_css(lbl_ai_text, css_ai)
-                        lbl_ai_text.set_use_markup(True)
-                        lbl_ai_text.set_markup(processed)
-                        content_container.pack_start(lbl_ai_text, False, False, 0)
+                        text_view = self._create_text_view(processed, self.ai_color)
+                        content_container.pack_start(text_view, False, False, 0)
                     full_text.append(seg)
                     
         # Create the play/stop button using the new refactored method.


### PR DESCRIPTION
## Summary
- add shared TextView helper that preserves clickable links and applies hanging indents for bullet lists
- render AI message text with TextView to enable consistent list formatting alongside inline images
- tag embedded links manually so they remain clickable after moving to TextView-based rendering

## Testing
- python -m compileall src

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69363b94f9788330969bc6cef7429da4)